### PR TITLE
macOS: align traffic light window controls with native behavior and appearance

### DIFF
--- a/src/titlebar/control_buttons.rs
+++ b/src/titlebar/control_buttons.rs
@@ -1,5 +1,5 @@
 use egui::{
-    Color32, CursorIcon, Painter, Pos2, Rect, Response, Sense, Stroke, StrokeKind, Ui, Vec2, vec2,
+    Color32, Painter, Pos2, Rect, Response, Sense, Shape, Stroke, StrokeKind, Ui, Vec2, vec2,
 };
 
 use crate::{TitleBar, titlebar::render_bar::title_bar_height};
@@ -231,7 +231,6 @@ impl TitleBar {
         let size = rect.width().min(rect.height());
         let center = rect.center();
         let half_size = size / 2.0;
-
         let stroke = Stroke::new(1.5, color);
         painter.line_segment(
             [
@@ -260,7 +259,7 @@ impl TitleBar {
     /// * `color` - The color of the icon strokes
     fn draw_mac_zoom_icon(&self, painter: &Painter, rect: Rect, color: Color32) {
         // Left top triangle
-        painter.add(egui::Shape::convex_polygon(
+        painter.add(Shape::convex_polygon(
             vec![
                 rect.left_top(),
                 rect.left_top() + vec2(rect.width() * 0.75, 0.0),
@@ -270,7 +269,7 @@ impl TitleBar {
             Stroke::NONE,
         ));
         // Right bottom triangle
-        painter.add(egui::Shape::convex_polygon(
+        painter.add(Shape::convex_polygon(
             vec![
                 rect.right_bottom(),
                 rect.right_bottom() - vec2(rect.width() * 0.75, 0.0),
@@ -337,9 +336,9 @@ impl TitleBar {
         if let Some(icon) = icon_type {
             let icon_color = if darken {
                 Color32::from_rgba_premultiplied(
-                    (icon_color.r() as f32 * 0.75) as u8,
-                    (icon_color.g() as f32 * 0.75) as u8,
-                    (icon_color.b() as f32 * 0.75) as u8,
+                    (icon_color.r() as f32 * 0.45) as u8,
+                    (icon_color.g() as f32 * 0.45) as u8,
+                    (icon_color.b() as f32 * 0.45) as u8,
                     icon_color.a(),
                 )
             } else {

--- a/src/titlebar/render_bar.rs
+++ b/src/titlebar/render_bar.rs
@@ -129,7 +129,7 @@ impl TitleBar {
                         let colored = controls_hovered || window_active;
                         let show_icons = controls_hovered;
 
-                        // Figure out which color will be inactive depending on luminance of titlebar
+                        // Figure out inactive color depending on luminance of titlebar
                         let rgba: Rgba = self.background_color.into();
                         let luminance = 0.2126 * rgba.r() + 0.7152 * rgba.g() + 0.0722 * rgba.b();
                         let inactive_color = if luminance < 0.55 {


### PR DESCRIPTION
**Motivation**

On macOS, window control buttons (“traffic lights”) have a number of subtle but important
behavioral and visual characteristics that differ from other platforms.

The previous implementation deviated from native AppKit behavior in several areas
(hover handling, cursor feedback, geometry, inactive window states), which resulted in
noticeable UX inconsistencies for macOS users.

This PR aligns the macOS traffic light controls more closely with native system behavior
and appearance, while keeping all changes strictly platform-specific.

**What’s changed**

This PR refines macOS traffic light controls to better match native behavior:

- Geometry & layout
  - Align button size and positioning with the native macOS title bar.
- Hover & interaction behavior
  - Remove hover tooltips to match native buttons.
  - Use the standard arrow cursor instead of a pointing hand.
  - Implement cluster hover behavior: hovering over the traffic light area activates all three buttons.
- Visual states
  - Add proper inactive window appearance.
  - Add pressed button states consistent with native behavior.
  - Improve glyph visibility and coloring for better contrast and fidelity.

All changes are applied only to macOS-specific code paths and do not affect other platforms.

**Notes**

This PR intentionally focuses on macOS fidelity and does not introduce any cross-platform
behavior changes. The goal is to make egui-desktop feel native on macOS while preserving
the existing architecture and APIs.

Feedback and suggestions are very welcome.